### PR TITLE
Rewrote create_or_first to not cause persistent instance warning to fire

### DIFF
--- a/sqla_wrapper/default_model.py
+++ b/sqla_wrapper/default_model.py
@@ -21,7 +21,7 @@ def get_default_model_class(db):
         @classmethod
         def create_or_first(cls, **attrs):
             """Tries to find a record with these attributes and creates
-                        one if it doesn't find one."""
+            one if it doesn't find one."""
             try:
                 return cls.first_or_error(**attrs)
             except ValueError:

--- a/sqla_wrapper/default_model.py
+++ b/sqla_wrapper/default_model.py
@@ -20,13 +20,12 @@ def get_default_model_class(db):
 
         @classmethod
         def create_or_first(cls, **attrs):
-            """Tries to create a new record, and if it fails
-            because already exists, return the first it founds."""
+            """Tries to find a record with these attributes and creates
+                        one if it doesn't find one."""
             try:
+                return cls.first_or_error(**attrs)
+            except ValueError:
                 return cls.create(**attrs)
-            except IntegrityError:
-                db.session.rollback()
-                return cls.first(**attrs)
 
         @classmethod
         def first(cls, **attrs):


### PR DESCRIPTION
When `Model.create_or_first` is called with the same primary key in the same session, the following SAWarning fires because of a conflict with the existing persistent object in the session:

```
SAWarning: New instance <User at 0x105e8c400> with identity key (<class 'model.user.User'>, (212416365317980171,), None) conflicts with persistent instance <User at 0x105e9f130>
  util.warn(
```

Rewriting the method to query before attempting the create fixes the issue.