### PR TITLE
"verbose" argument to alembic.history cli command

### DIFF
--- a/sqla_wrapper/cli/click_cli.py
+++ b/sqla_wrapper/cli/click_cli.py
@@ -64,11 +64,11 @@ def _get_cli(alembic, group):
         "-e", "--end", default="head",
         help="To this revision (including it.)",
     )
-    def history(start, end):
+    def history(verbose, start, end):
         """Get the list of revisions in chronological order.
         You can optionally specify the range of revisions to return.
         """
-        alembic.history(start=start, end=end)
+        alembic.history(verbose=verbose, start=start, end=end)
 
     @group.command()
     @click.argument("target", default="head")


### PR DESCRIPTION
without this parameter command actually doesn't work:

```
 python manage.py db history
Traceback (most recent call last):
  File "manage.py", line 41, in <module>
    cli()
  File "/home/krnr/.pyenv/versions/ard38/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/krnr/.pyenv/versions/ard38/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/krnr/.pyenv/versions/ard38/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/krnr/.pyenv/versions/ard38/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/krnr/.pyenv/versions/ard38/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/krnr/.pyenv/versions/ard38/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/krnr/.pyenv/versions/ard38/lib/python3.8/site-packages/sqla_wrapper/cli/click_cli.py", line 71, in history
    alembic.history(verbose, start=start, end=end)
TypeError: history() takes 1 positional argument but 2 positional arguments (and 2 keyword-only arguments) were given
```